### PR TITLE
Improve MCP setup, tooling, and documentation

### DIFF
--- a/cli/commands/setup-mcp.command.ts
+++ b/cli/commands/setup-mcp.command.ts
@@ -16,10 +16,12 @@ interface McpServer {
 
 interface McpConfig {
   mcpServers?: Record<string, McpServer>;
+  servers?: Record<string, McpServer>;
 }
 
 /**
  * Get the appropriate MCP config file path based on client type
+ * VS Code reads from the user profile (Application Support/Code/User), not ~/.vscode/
  */
 function getMcpConfigPath(client: 'cursor' | 'claude-code' | 'vscode' | 'claude-desktop'): string {
   const homeDir = os.homedir();
@@ -28,10 +30,8 @@ function getMcpConfigPath(client: 'cursor' | 'claude-code' | 'vscode' | 'claude-
     case 'cursor':
       return path.join(homeDir, '.cursor', 'mcp.json');
     case 'claude-code':
-      // Claude Code uses the same config as Claude Desktop for now
       return path.join(homeDir, '.claude', 'mcp.json');
     case 'claude-desktop':
-      // macOS
       if (process.platform === 'darwin') {
         return path.join(
           homeDir,
@@ -41,15 +41,21 @@ function getMcpConfigPath(client: 'cursor' | 'claude-code' | 'vscode' | 'claude-
           'claude_desktop_config.json',
         );
       }
-      // Windows
       if (process.platform === 'win32') {
         return path.join(homeDir, 'AppData', 'Roaming', 'Claude', 'claude_desktop_config.json');
       }
-      // Linux
       return path.join(homeDir, '.config', 'Claude', 'claude_desktop_config.json');
-    case 'vscode':
-      // VS Code settings are in settings.json, we'll provide CLI command instead
-      return path.join(homeDir, '.vscode', 'mcp.json');
+    case 'vscode': {
+      // VS Code (with Copilot) reads MCP config from user profile, not ~/.vscode/
+      if (process.platform === 'darwin') {
+        return path.join(homeDir, 'Library', 'Application Support', 'Code', 'User', 'mcp.json');
+      }
+      if (process.platform === 'win32') {
+        const appData = process.env.APPDATA || path.join(homeDir, 'AppData', 'Roaming');
+        return path.join(appData, 'Code', 'User', 'mcp.json');
+      }
+      return path.join(homeDir, '.config', 'Code', 'User', 'mcp.json');
+    }
     default:
       throw new Error(`Unknown client: ${client}`);
   }
@@ -58,31 +64,34 @@ function getMcpConfigPath(client: 'cursor' | 'claude-code' | 'vscode' | 'claude-
 /**
  * Get the command to run the MCP server
  */
-function getMcpServerCommand(): { command: string; args?: string[]; cwd?: string } {
-  const isGlobal = process.argv.includes('--global');
+function getMcpServerCommand(options: { global?: boolean }): {
+  command: string;
+  args?: string[];
+  cwd?: string;
+} {
+  const isGlobal = options?.global === true;
 
   if (isGlobal) {
-    return {
-      command: 'archdoc-mcp-server',
-    };
-  } else {
-    // For local: use npx to find the binary in node_modules/.bin
-    return {
-      command: 'npx',
-      args: ['--yes', 'archdoc-mcp-server'],
-    };
+    return { command: 'archdoc-mcp-server' };
   }
+  return {
+    command: 'npx',
+    args: ['--yes', 'archdoc-mcp-server'],
+  };
 }
 
 /**
  * Read existing MCP config file or create new one
  */
-async function readMcpConfig(configPath: string): Promise<McpConfig> {
+async function readMcpConfig(configPath: string, client: string): Promise<McpConfig> {
   try {
     const content = await fs.readFile(configPath, 'utf-8');
-    return JSON.parse(content);
+    const parsed = JSON.parse(content) as McpConfig;
+    return parsed;
   } catch (_error) {
-    // File doesn't exist or is invalid, return empty config
+    if (client === 'vscode') {
+      return { servers: {} };
+    }
     return { mcpServers: {} };
   }
 }
@@ -132,7 +141,7 @@ async function ensureApiKey(): Promise<boolean> {
 /**
  * Register MCP server in the specified client
  */
-export async function setupMcp(client: string, _options: any) {
+export async function setupMcp(client: string, options: { global?: boolean } = {}) {
   const validClients = ['cursor', 'claude-code', 'vscode', 'claude-desktop'];
 
   if (!validClients.includes(client)) {
@@ -142,38 +151,41 @@ export async function setupMcp(client: string, _options: any) {
   }
 
   try {
-    // Check if API key is configured
     const hasApiKey = await ensureApiKey();
     if (!hasApiKey && client !== 'vscode') {
-      // VS Code can prompt for API key at runtime
       logger.warn('Continuing without local config (will need to configure in client UI)');
     }
 
     const configPath = getMcpConfigPath(
       client as 'cursor' | 'claude-code' | 'vscode' | 'claude-desktop',
     );
-    const mcpCommand = getMcpServerCommand();
+    const mcpCommand = getMcpServerCommand(options);
 
     logger.info(`Setting up ArchDoc MCP for ${chalk.bold(client)}...`);
     logger.info(`Config path: ${configPath}`);
 
-    // Read existing config
-    const config = await readMcpConfig(configPath);
+    const config = await readMcpConfig(configPath, client);
 
-    // Ensure mcpServers exists
-    if (!config.mcpServers) {
-      config.mcpServers = {};
-    }
-
-    // Add/update archdoc server
-    config.mcpServers['archdoc'] = {
-      type: 'stdio',
+    const serverEntry = {
+      type: 'stdio' as const,
       command: mcpCommand.command,
       ...(mcpCommand.args && { args: mcpCommand.args }),
       ...(mcpCommand.cwd && { cwd: mcpCommand.cwd }),
     };
 
-    // Write config
+    if (client === 'vscode') {
+      // VS Code (Copilot) uses "servers" key and reads from user profile
+      if (!config.servers) {
+        config.servers = {};
+      }
+      config.servers['archdoc'] = serverEntry;
+    } else {
+      if (!config.mcpServers) {
+        config.mcpServers = {};
+      }
+      config.mcpServers['archdoc'] = serverEntry;
+    }
+
     await writeMcpConfig(configPath, config);
 
     // Success message with client-specific instructions
@@ -199,11 +211,10 @@ export async function setupMcp(client: string, _options: any) {
 
       case 'vscode':
         logger.info(chalk.bold('📋 Next steps for VS Code + GitHub Copilot:'));
-        logger.info(`1. The config has been created: ${configPath}`);
-        logger.info('2. Open VS Code settings (Cmd+, or Ctrl+,)');
-        logger.info('3. Search for "MCP" or "Model Context Protocol"');
-        logger.info('4. Configure the server settings if needed');
-        logger.info('5. Restart VS Code');
+        logger.info(`1. The config has been written to: ${configPath}`);
+        logger.info('2. Restart VS Code (or Reload Window)');
+        logger.info('3. Open Chat (Ctrl+Shift+I / Cmd+Shift+I) and use Copilot');
+        logger.info('4. MCP servers appear in Extensions view (@mcp) or run "MCP: List Servers"');
         break;
 
       case 'claude-desktop':
@@ -232,6 +243,7 @@ export function registerSetupMcpCommand(program: any) {
     .description(
       'Set up ArchDoc MCP server for an AI client (cursor, claude-code, vscode, claude-desktop)',
     )
+    .option('--global', 'Use global archdoc-mcp-server binary (for global installs)')
     .action(setupMcp);
 
   // Also add a convenience command

--- a/docs/MCP-SETUP.md
+++ b/docs/MCP-SETUP.md
@@ -65,6 +65,8 @@ archdoc setup-mcp claude-desktop
 
 Then restart Claude Desktop.
 
+**Tip:** If you installed ArchDoc globally (`npm install -g @techdebtgpt/archdoc-generator`) and want the MCP config to run the binary directly (no npx), add `--global`: e.g. `archdoc setup-mcp cursor --global`. Without `--global`, the config uses `npx --yes archdoc-mcp-server`, which works for both global and local installs.
+
 ## Configuration Flexibility: Project Config vs Editor Environment
 
 ArchDoc's MCP server intelligently detects which configuration to use. You have two options:
@@ -177,13 +179,19 @@ The setup command configures ArchDoc at `~/.claude/mcp.json`.
 
 ### VS Code + GitHub Copilot
 
-The setup command creates a configuration at `~/.vscode/mcp.json`.
+The setup command writes to the **VS Code user profile** MCP config (used by GitHub Copilot). Path by OS:
+
+- **macOS:** `~/Library/Application Support/Code/User/mcp.json`
+- **Linux:** `~/.config/Code/User/mcp.json`
+- **Windows:** `%APPDATA%\Code\User\mcp.json`
+
+You can open this file from VS Code: **Command Palette** (Ctrl+Shift+P / Cmd+Shift+P) → **MCP: Open User Configuration**.
 
 **After setup:**
 
-1. Restart VS Code
-2. The MCP server should be available to Copilot
-3. Use Copilot Chat with ArchDoc commands
+1. Restart VS Code (or **Developer: Reload Window**)
+2. Open **Chat** (Ctrl+Shift+I / Cmd+Shift+I) and use Copilot
+3. MCP servers appear in **Extensions** view (search `@mcp`) or run **MCP: List Servers** from the Command Palette
 
 **Example prompts:**
 
@@ -531,7 +539,7 @@ A: Delete the archdoc entry from the client's config file:
 
 - Cursor: `~/.cursor/mcp.json`
 - Claude Code: `~/.claude/mcp.json`
-- VS Code: `~/.vscode/mcp.json`
+- VS Code: macOS `~/Library/Application Support/Code/User/mcp.json`, Linux `~/.config/Code/User/mcp.json`, Windows `%APPDATA%\Code\User\mcp.json` (or run **MCP: Open User Configuration** in VS Code)
 - Claude Desktop: See paths above for your OS
 
 ## Support

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
       },
       "bin": {
         "archdoc": "dist/cli/index.js",
-        "archdoc-generate-mcp": "dist/cli/generate-mcp-json.js",
         "archdoc-mcp-server": "dist/src/mcp-server/index.js"
       },
       "devDependencies": {
@@ -112,6 +111,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -610,7 +610,8 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
       "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -1325,6 +1326,7 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.79.tgz",
       "integrity": "sha512-ZLAs5YMM5N2UXN3kExMglltJrKKoW7hs3KMZFlXUnD7a5DFKBYxPFMeXA4rT+uvTxuJRZPCYX0JKI5BhyAWx4A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -1348,6 +1350,7 @@
       "resolved": "https://registry.npmjs.org/@langchain/google-genai/-/google-genai-0.1.12.tgz",
       "integrity": "sha512-0Ea0E2g63ejCuormVxbuoyJQ5BYN53i2/fb6WP8bMKzyh+y43R13V8JqOtr3e/GmgNyv3ou/VeaZjx7KAvu/0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@google/generative-ai": "^0.24.0",
         "zod-to-json-schema": "^3.22.4"
@@ -1750,6 +1753,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.0.tgz",
       "integrity": "sha512-xpr/lmLPQEj+TUnHmR+Ab91/glhJvsqcjB+yY0Ix9GO70H6Lb4FHH5GeqdOE5btAx7eIMwuHkp4H2MSkLcqWbA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1856,6 +1860,7 @@
       "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.2",
         "@typescript-eslint/types": "8.46.2",
@@ -2114,6 +2119,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2550,6 +2556,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -3336,6 +3343,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3392,6 +3400,7 @@
       "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4240,6 +4249,7 @@
       "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",
@@ -4711,6 +4721,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -6461,6 +6472,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7509,6 +7521,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -7630,6 +7643,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7969,6 +7983,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -7978,6 +7993,7 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
       "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.24.1"
       }

--- a/src/mcp-server/index.ts
+++ b/src/mcp-server/index.ts
@@ -2,17 +2,6 @@
 
 /**
  * MCP Server for Architecture Documentation Generator
- * Refactored for maintainability and testability
- *
- * Architecture:
- * - Types & Interfaces (types.ts)
- * - Tool Registry (tools/tool-registry.ts) - Tool definitions
- * - Tool Handlers (tools/handlers.ts) - Tool implementations
- * - Services (services/) - Business logic
- *   ├── ConfigService - Configuration management
- *   ├── DocumentationService - Documentation generation
- *   └── VectorStoreService - RAG vector store
- * - This file: MCP Protocol implementation & orchestration
  */
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
@@ -25,12 +14,19 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import * as path from 'path';
 import * as fs from 'fs/promises';
-import { Logger } from '../utils/logger';
 import { getAllTools } from './tools/tool-registry';
 import { getToolHandler } from './tools/handlers';
 import { ConfigService } from './services/config.service';
 
-const logger = new Logger('MCP-Server');
+/**
+ * Simple logger for MCP server 
+ */
+const logger = {
+  info: (message: string) => console.error(`[INFO] ${message}`),
+  error: (message: string, error?: unknown) =>
+    console.error(`[ERROR] ${message}`, error || ''),
+  warn: (message: string) => console.error(`[WARN] ${message}`),
+};
 
 /**
  * MCP Server instance
@@ -116,24 +112,48 @@ server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
 
 /**
  * Handle tool calls
- * Routes to appropriate handler with proper context
+ * Routes to appropriate handler with context
  */
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args = {} } = request.params;
-  const projectPath = process.cwd();
+  const explicitProjectPath = (args as any).project_path;
+  const projectPath = explicitProjectPath || process.cwd();
+
+  logger.info(
+    `CallTool request received: ${name}${
+      explicitProjectPath ? ` (explicit path: ${explicitProjectPath})` : ` (cwd: ${projectPath})`
+    }`,
+  );
 
   try {
     // Get the handler for this tool
     const handler = getToolHandler(name);
     if (!handler) {
-      throw new Error(`Unknown tool: ${name}`);
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Unknown tool: ${name}`,
+          },
+        ],
+        isError: true,
+      };
     }
 
-    // Initialize configuration
-    const configService = ConfigService.getInstance();
-    const config = await configService.initializeConfig(projectPath);
+    // Create context for handler (CLI-style: load config once per call, pass it in)
+    // Tools that don't need config can ignore it; tools that do should rely on context.config.
+    let config = null;
+    try {
+      // Avoid forcing config for setup/check tools (they intentionally work without it)
+      if (name !== 'check_config' && name !== 'setup_config') {
+        const configService = ConfigService.getInstance();
+        config = await configService.initializeConfig(projectPath);
+      }
+    } catch {
+      // Config missing/invalid is handled by individual tools as needed
+      config = null;
+    }
 
-    // Create context for handler
     const context = {
       projectPath,
       config,
@@ -143,7 +163,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     // Call handler with context
     const result = await handler(args, context);
 
-    // Convert ToolResponse to MCP ServerResult format
     return {
       content: result.content,
       isError: result.isError,
@@ -164,16 +183,17 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 });
 
 /**
- * Start the MCP server on stdio
+ * Start the MCP server on stdio transport
  */
-async function start() {
+export async function startServer(): Promise<void> {
   const transport = new StdioServerTransport();
+  logger.info('ArchDoc MCP Server starting...');
   await server.connect(transport);
-  logger.info('ArchDoc MCP Server started on stdio transport');
+  // Note: connect() never returns - server runs indefinitely
 }
 
 // Start server
-start().catch((error) => {
+startServer().catch((error) => {
   logger.error('Failed to start MCP server', error);
   process.exit(1);
 });

--- a/src/mcp-server/services/documentation.service.ts
+++ b/src/mcp-server/services/documentation.service.ts
@@ -10,18 +10,44 @@ import { DocumentationOrchestrator } from '../../orchestrator/documentation-orch
 import { AgentRegistry } from '../../agents/agent-registry';
 import { FileSystemScanner } from '../../scanners/file-system-scanner';
 import { MultiFileMarkdownFormatter } from '../../formatters/multi-file-markdown-formatter';
+import { ArchitectureAnalyzerAgent } from '../../agents/architecture-analyzer-agent';
+import { FileStructureAgent } from '../../agents/file-structure-agent';
+import { DependencyAnalyzerAgent } from '../../agents/dependency-analyzer-agent';
+import { PatternDetectorAgent } from '../../agents/pattern-detector-agent';
+import { FlowVisualizationAgent } from '../../agents/flow-visualization-agent';
+import { SchemaGeneratorAgent } from '../../agents/schema-generator-agent';
+import { SecurityAnalyzerAgent } from '../../agents/security-analyzer-agent';
+import { KPIAnalyzerAgent } from '../../agents/kpi-analyzer-agent';
+import { LLMService } from '../../llm/llm-service';
 import * as fs from 'fs/promises';
 
 const logger = new Logger('DocumentationService');
 
 /**
- * Supported analysis depths
+ * Supported analysis depths (matches CLI exactly)
  */
 const DEPTH_CONFIG = {
-  quick: { enabled: false, maxIterations: 0, clarityThreshold: 0 },
-  normal: { enabled: true, maxIterations: 5, clarityThreshold: 80 },
-  deep: { enabled: true, maxIterations: 10, clarityThreshold: 90 },
+  quick: { maxIterations: 2, clarityThreshold: 70, maxQuestions: 2, skipSelfRefinement: true },
+  normal: { maxIterations: 5, clarityThreshold: 80, maxQuestions: 3, skipSelfRefinement: false },
+  deep: { maxIterations: 10, clarityThreshold: 90, maxQuestions: 5, skipSelfRefinement: false },
 };
+
+/**
+ * Register all available agents (like CLI does)
+ */
+function registerAgents(): AgentRegistry {
+  const agentRegistry = new AgentRegistry();
+  agentRegistry.register(new ArchitectureAnalyzerAgent());
+  agentRegistry.register(new FileStructureAgent());
+  agentRegistry.register(new DependencyAnalyzerAgent());
+  agentRegistry.register(new PatternDetectorAgent());
+  agentRegistry.register(new FlowVisualizationAgent());
+  agentRegistry.register(new SchemaGeneratorAgent());
+  agentRegistry.register(new SecurityAnalyzerAgent());
+  agentRegistry.register(new KPIAnalyzerAgent());
+  logger.info(`Registered ${agentRegistry.getAllAgents().length} agents: ${agentRegistry.getAllAgents().map(a => a.getMetadata().name).join(', ')}`);
+  return agentRegistry;
+}
 
 /**
  * Documentation service
@@ -33,6 +59,36 @@ export class DocumentationService {
   ) {}
 
   /**
+   * Get search mode, retrieval strategy, and embeddings provider from config.
+   * Default: keyword for MCP (CLI defaults to vector). Used by generateDocumentation, updateDocumentation, runSelectiveAgents.
+   */
+  private getSearchOptions(): {
+    searchMode: 'vector' | 'keyword';
+    retrievalStrategy: 'vector' | 'graph' | 'hybrid' | 'smart' | undefined;
+    embeddingsProvider: 'local' | 'openai' | 'google' | undefined;
+  } {
+    const configSearchMode = this.config.searchMode?.mode as 'vector' | 'keyword' | undefined;
+    const searchMode = configSearchMode || 'keyword';
+    const configRetrievalStrategy = this.config.searchMode?.strategy as
+      | 'vector'
+      | 'graph'
+      | 'hybrid'
+      | 'smart'
+      | undefined;
+    const retrievalStrategy =
+      searchMode === 'vector' ? configRetrievalStrategy || 'hybrid' : undefined;
+    const embeddingsProvider =
+      searchMode === 'vector'
+        ? (this.config.searchMode?.embeddingsProvider as
+            | 'local'
+            | 'openai'
+            | 'google'
+            | undefined) || 'local'
+        : undefined;
+    return { searchMode, retrievalStrategy, embeddingsProvider };
+  }
+
+  /**
    * Generate documentation
    */
   async generateDocumentation(options: {
@@ -41,45 +97,126 @@ export class DocumentationService {
     focusArea?: string;
     selectiveAgents?: string[];
     maxCostDollars?: number;
+    force?: boolean;
+    since?: string;
   }): Promise<{
     output: any;
     docsPath: string;
   }> {
     const depth = options.depth || 'normal';
-    const docsPath = options.outputDir || path.join(this.projectPath, '.arch-docs');
+    // IMPORTANT: if outputDir is relative (".arch-docs"), resolve it against projectPath
+    // (CLI behavior: default is <project>/.arch-docs, not <cwd>/.arch-docs)
+    const docsPath = options.outputDir
+      ? path.isAbsolute(options.outputDir)
+        ? options.outputDir
+        : path.join(this.projectPath, options.outputDir)
+      : path.join(this.projectPath, '.arch-docs');
     const focusArea = options.focusArea;
     const selectiveAgents = options.selectiveAgents;
     const maxCostDollars = options.maxCostDollars || 5.0;
+    const force = options.force || false;
+    const since = options.since;
+    
+    // Get depth config (matches CLI exactly)
+    const depthConfig = DEPTH_CONFIG[depth];
+    const { searchMode, retrievalStrategy, embeddingsProvider } = this.getSearchOptions();
+
+    // Check for existing documentation (mirror CLI behavior exactly)
+    const hasExistingDocs = await this.checkExistingDocumentation(docsPath);
+    
+    // Determine mode exactly like CLI does:
+    // 1. Incremental mode WITH prompt: hasExistingDocs && focusArea provided → enhance specific area
+    // 2. Refinement check mode: hasExistingDocs && NO focusArea → check for improvements
+    // 3. Full generation: !hasExistingDocs → generate from scratch
+    const isIncrementalMode = hasExistingDocs && !!focusArea;
+    const isRefinementCheckMode = hasExistingDocs && !focusArea && !selectiveAgents;
+
+    // Full generation: clean output dir before run (mirror CLI --clean behavior, avoid stale files)
+    if (!hasExistingDocs) {
+      try {
+        await fs.access(docsPath);
+        await fs.rm(docsPath, { recursive: true, force: true });
+        logger.info(`Cleaned output directory: ${docsPath}`);
+      } catch {
+        // Dir does not exist, ignore
+      }
+      await fs.mkdir(docsPath, { recursive: true });
+    }
 
     logger.info(`Generating documentation for ${this.projectPath}...`);
-
-    const agentRegistry = new AgentRegistry();
+    
+    // Initialize LLMService with config BEFORE registering agents (matches CLI approach)
+    LLMService.getInstance(this.config);
+    
+    const agentRegistry = registerAgents();
     const scanner = new FileSystemScanner();
     const orchestrator = new DocumentationOrchestrator(agentRegistry, scanner, this.config);
 
-    const output = await orchestrator.generateDocumentation(this.projectPath, {
-      userPrompt: focusArea,
-      selectiveAgents,
-      maxCostDollars,
-      iterativeRefinement: {
-        ...DEPTH_CONFIG[depth],
-        minImprovement: 10,
-      },
-      agentOptions: {
-        searchMode: this.config.searchMode?.mode || 'keyword',
-      },
-    });
+    // Pass options exactly like CLI does - match ALL CLI options
+    try {
+      const output = await orchestrator.generateDocumentation(this.projectPath, {
+        maxTokens: 100000, // Match CLI exactly
+        maxCostDollars, // Match CLI
+        parallel: true, // Match CLI exactly
+        userPrompt: focusArea, // Match CLI
+        selectiveAgents, // Match CLI
+        incrementalMode: isIncrementalMode || isRefinementCheckMode, // Match CLI: pass if docs exist
+        existingDocsPath: (isIncrementalMode || isRefinementCheckMode) ? docsPath : undefined, // Match CLI: pass path if docs exist
+        iterativeRefinement: {
+          enabled: true, // Match CLI: default enabled
+          maxIterations: depthConfig.maxIterations, // Match CLI
+          clarityThreshold: depthConfig.clarityThreshold, // Match CLI
+          minImprovement: 10, // Match CLI
+        },
+        runName: process.env.ARCHDOC_RUN_NAME, // Match CLI: custom run name from env
+        agentOptions: {
+          runnableConfig: {
+            runName: 'DocumentationGeneration-Complete', // Match CLI exactly
+          },
+          maxQuestionsPerIteration: depthConfig.maxQuestions, // Match CLI
+          skipSelfRefinement: depthConfig.skipSelfRefinement, // Match CLI
+          searchMode, // Match CLI: vector or keyword
+        },
+        retrievalStrategy, // Match CLI: hybrid/vector/graph/smart
+        embeddingsProvider, // Match CLI: local/openai/google
+        force, // Match CLI: from user option
+        since, // Match CLI: git commit/branch/tag
+      });
 
-    // Write to files
-    const formatter = new MultiFileMarkdownFormatter();
-    await formatter.format(output, {
-      outputDir: docsPath,
-      includeMetadata: true,
-      includeTOC: true,
-      includeNavigation: true,
-    });
+      // Write to files
+      const formatter = new MultiFileMarkdownFormatter();
+      await formatter.format(output, {
+        outputDir: docsPath,
+        includeMetadata: true,
+        includeTOC: true,
+        includeNavigation: true,
+      });
 
-    return { output, docsPath };
+      return { output, docsPath };
+    } catch (error) {
+      // Handle special case: refinement check found no improvements needed (matches CLI behavior)
+      if (error instanceof Error && error.message === 'NO_IMPROVEMENTS_NEEDED') {
+        logger.info('✅ Documentation is up-to-date, no changes needed');
+        // Return empty output structure with proper metadata (matches CLI behavior)
+        const emptyOutput: any = {
+          projectName: this.projectPath,
+          timestamp: new Date(),
+          version: '1.0.0',
+          overview: {},
+          architecture: {},
+          fileStructure: {},
+          dependencies: {},
+          customSections: new Map(),
+          metadata: {
+            agentsExecuted: [],
+            totalTokensUsed: 0,
+            message: 'No improvements needed - documentation is up-to-date. To force regeneration, delete the .arch-docs directory or use a focusArea/selectiveAgents parameter.',
+          },
+        };
+        return { output: emptyOutput, docsPath };
+      }
+      throw error;
+    }
   }
 
   /**
@@ -89,22 +226,38 @@ export class DocumentationService {
     output: any;
     docsPath: string;
   }> {
-    const docsPath = options.existingDocsPath || path.join(this.projectPath, '.arch-docs');
+    // Keep CLI semantics: relative paths are relative to projectPath
+    const docsPath = options.existingDocsPath
+      ? path.isAbsolute(options.existingDocsPath)
+        ? options.existingDocsPath
+        : path.join(this.projectPath, options.existingDocsPath)
+      : path.join(this.projectPath, '.arch-docs');
     const prompt = options.prompt;
 
     logger.info(`Updating documentation with prompt: "${prompt}"`);
 
-    const agentRegistry = new AgentRegistry();
+    // Initialize LLMService with config BEFORE registering agents (matches CLI approach)
+    LLMService.getInstance(this.config);
+    
+    const agentRegistry = registerAgents();
     const scanner = new FileSystemScanner();
     const orchestrator = new DocumentationOrchestrator(agentRegistry, scanner, this.config);
+    const { searchMode, retrievalStrategy, embeddingsProvider } = this.getSearchOptions();
 
     const output = await orchestrator.generateDocumentation(this.projectPath, {
+      maxTokens: 100000, // Match CLI
+      parallel: true, // Match CLI
       userPrompt: prompt,
       incrementalMode: true,
       existingDocsPath: docsPath,
       agentOptions: {
-        searchMode: this.config.searchMode?.mode || 'keyword',
+        runnableConfig: {
+          runName: 'DocumentationGeneration-Complete', // Match CLI
+        },
+        searchMode, // Match CLI
       },
+      retrievalStrategy, // Match CLI
+      embeddingsProvider, // Match CLI
     });
 
     // Write updates
@@ -126,23 +279,86 @@ export class DocumentationService {
     selectiveAgents: string[];
     userPrompt?: string;
   }): Promise<any> {
-    const agentRegistry = new AgentRegistry();
+    // Initialize LLMService with config BEFORE registering agents (matches CLI approach)
+    LLMService.getInstance(this.config);
+    
+    const agentRegistry = registerAgents();
     const scanner = new FileSystemScanner();
     const orchestrator = new DocumentationOrchestrator(agentRegistry, scanner, this.config);
+    const { searchMode, retrievalStrategy, embeddingsProvider } = this.getSearchOptions();
 
     return await orchestrator.generateDocumentation(this.projectPath, {
+      maxTokens: 100000, // Match CLI
+      parallel: true, // Match CLI
       selectiveAgents: options.selectiveAgents,
       userPrompt: options.userPrompt,
       agentOptions: {
-        searchMode: this.config.searchMode?.mode || 'keyword',
+        runnableConfig: {
+          runName: 'DocumentationGeneration-Complete', // Match CLI
+        },
+        searchMode, // Match CLI
       },
+      retrievalStrategy, // Match CLI
+      embeddingsProvider, // Match CLI
     });
+  }
+
+  /**
+   * Check if existing documentation exists
+   */
+  private async checkExistingDocumentation(docsPath: string): Promise<boolean> {
+    try {
+      // Match CLI semantics: treat docs as "existing" only if key files exist.
+      // This avoids mistakenly entering refinement-check mode due to a single stray .md file.
+      await fs.access(docsPath);
+      const indexPath = path.join(docsPath, 'index.md');
+      const metadataPath = path.join(docsPath, 'metadata.md');
+
+      const hasIndex = await fs
+        .access(indexPath)
+        .then(() => true)
+        .catch(() => false);
+      const hasMetadata = await fs
+        .access(metadataPath)
+        .then(() => true)
+        .catch(() => false);
+
+      return hasIndex && hasMetadata;
+    } catch {
+      return false;
+    }
   }
 
   /**
    * Format generation output
    */
   formatOutput(output: any, metadata: Record<string, any>): string {
+    // If orchestrator determined no improvements were needed (refinement-check mode),
+    // avoid reporting "generated successfully" (no agents run, no files updated).
+    const noImprovements =
+      output?.metadata?.agentsExecuted?.length === 0 &&
+      output?.metadata?.totalTokensUsed === 0 &&
+      typeof output?.metadata?.message === 'string' &&
+      output.metadata.message.includes('No improvements needed');
+
+    if (noImprovements) {
+      return `✅ Documentation is up-to-date (no regeneration needed).
+
+**Output**: ${metadata.docsPath}
+**Agents Executed**: 0
+**Total Tokens**: 0
+**Files Generated**: 0
+
+**Why**: ${output.metadata.message}
+
+📖 Use \`query_documentation\` to ask questions about the existing docs.
+
+If you expected a full regeneration:
+- Pass \`focusArea\` (any value) to force an enhancement run, or
+- Pass \`selectiveAgents\` to regenerate specific sections, or
+- Delete the output directory and rerun.`;
+    }
+
     return `✅ Documentation generated successfully!
 
 **Output**: ${metadata.docsPath}

--- a/src/mcp-server/tools/handler-factory.ts
+++ b/src/mcp-server/tools/handler-factory.ts
@@ -19,7 +19,22 @@ export function createSelectiveAgentHandler(
 ): ContextualToolHandler {
   return async (args: any, context) => {
     try {
-      const docService = new DocumentationService(context.config, context.projectPath);
+      // Use project_path from args if provided, otherwise use context.projectPath (CodeWave pattern)
+      const project_path = args.project_path;
+      const projectPath = project_path || context.projectPath;
+
+      if (!context.config) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: '❌ Error: Configuration not found. Please run: archdoc config --init or set environment variables (ANTHROPIC_API_KEY, etc.)',
+            },
+          ],
+          isError: true,
+        };
+      }
+      const docService = new DocumentationService(context.config, projectPath);
 
       // Build user prompt if prefix provided
       let userPrompt = userPromptPrefix;
@@ -191,8 +206,10 @@ export function createCheckConfigHandler(): ContextualToolHandler {
  * Create setup config handler
  */
 export function createSetupConfigHandler(): ContextualToolHandler {
-  return async (args: any, _context) => {
-    const projectPath = process.cwd();
+  return async (args: any, context) => {
+    // Use project_path from args if provided, otherwise use context.projectPath (CodeWave pattern)
+    const project_path = args.project_path;
+    const projectPath = project_path || context.projectPath;
     const configPath = path.join(projectPath, '.archdoc.config.json');
 
     const {

--- a/src/mcp-server/tools/handlers.ts
+++ b/src/mcp-server/tools/handlers.ts
@@ -5,9 +5,11 @@
  */
 
 import * as path from 'path';
+import * as fs from 'fs/promises';
 import { ContextualToolHandler } from '../types';
 import { DocumentationService } from '../services/documentation.service';
 import { VectorStoreService } from '../services/vector-store.service';
+import { ConfigService } from '../services/config.service';
 import {
   createSelectiveAgentHandler,
   createCheckConfigHandler,
@@ -16,28 +18,109 @@ import {
 
 /**
  * Handler: check_config
+ * Accepts project_path parameter (like CodeWave's repo_path)
  */
-export const handleCheckConfig = createCheckConfigHandler();
+export const handleCheckConfig: ContextualToolHandler = async (args, context) => {
+  const { project_path } = args as { project_path?: string };
+  // Use project_path from args if provided, otherwise use context.projectPath
+  const projectPath = project_path || context.projectPath;
+  
+  // Call the factory handler with updated context
+  const handler = createCheckConfigHandler();
+  const updatedContext = {
+    ...context,
+    projectPath,
+  };
+  return handler({}, updatedContext);
+};
 
 /**
  * Handler: setup_config
+ * Accepts project_path parameter (like CodeWave's repo_path)
  */
-export const handleSetupConfig = createSetupConfigHandler();
+export const handleSetupConfig: ContextualToolHandler = async (args, context) => {
+  const { project_path, ...restArgs } = args as { project_path?: string; [key: string]: any };
+  // Use project_path from args if provided, otherwise use context.projectPath
+  const updatedContext = {
+    ...context,
+    projectPath: project_path || context.projectPath,
+  };
+  const handler = createSetupConfigHandler();
+  return handler(restArgs, updatedContext);
+};
 
 /**
  * Handler: generate_documentation
+ * Accepts project_path parameter (like CodeWave's repo_path)
  */
 export const handleGenerateDocumentation: ContextualToolHandler = async (args, context) => {
-  const { outputDir, depth = 'normal', focusArea, selectiveAgents, maxCostDollars = 5.0 } = args;
+  const { project_path, outputDir, depth = 'normal', focusArea, selectiveAgents, maxCostDollars = 5.0, force = false, since } = args;
 
   try {
-    const docService = new DocumentationService(context.config, context.projectPath);
+    // CodeWave approach: use project_path from args if provided, otherwise context.projectPath
+    const projectPath = project_path || context.projectPath;
+    try {
+      await fs.access(projectPath);
+    } catch {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `❌ Error: Project path does not exist: ${projectPath}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    // CodeWave approach: load config in handler if needed
+    let config = context.config;
+    if (!config) {
+      try {
+        const configService = ConfigService.getInstance();
+        config = await configService.initializeConfig(projectPath);
+      } catch (error) {
+        // Config loading failed
+      }
+    }
+
+    // Validate config exists and has API keys
+    if (!config) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: '❌ Error: Configuration not found. Please run: archdoc config --init or set environment variables (ANTHROPIC_API_KEY, etc.)',
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    if (!config.apiKeys || Object.keys(config.apiKeys).length === 0) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: '❌ Error: No API keys configured. Please run: archdoc config --init',
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    // Note: No pre-scan needed - orchestrator will scan internally (matches CLI approach)
+    // This removes redundant scanning and matches CLI behavior where scan happens in orchestrator
+
+    const docService = new DocumentationService(config, projectPath);
     const { output, docsPath } = await docService.generateDocumentation({
       outputDir,
       depth,
       focusArea,
       selectiveAgents,
       maxCostDollars,
+      force: force as boolean,
+      since: since as string | undefined,
     });
 
     // Initialize vector store for RAG
@@ -55,11 +138,55 @@ export const handleGenerateDocumentation: ContextualToolHandler = async (args, c
       ],
     };
   } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    // Specific error handling
+    if (errorMessage.includes('quota') || errorMessage.includes('rate limit')) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: '❌ Error: LLM API quota exceeded. Please check your API key limits and try again later.',
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    if (errorMessage.includes('ENOSPC')) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: '❌ Error: Disk space full. Cannot write documentation files.',
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    if (errorMessage.includes('EACCES') || errorMessage.includes('EPERM')) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: '❌ Error: Permission denied. Check write permissions for the output directory.',
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    context.logger.error('Documentation generation failed', {
+      error: errorMessage,
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+
     return {
       content: [
         {
           type: 'text',
-          text: `Error: ${error instanceof Error ? error.message : String(error)}`,
+          text: `❌ Error: ${errorMessage}`,
         },
       ],
       isError: true,
@@ -69,10 +196,13 @@ export const handleGenerateDocumentation: ContextualToolHandler = async (args, c
 
 /**
  * Handler: query_documentation
+ * Accepts project_path parameter (like CodeWave's repo_path)
  */
 export const handleQueryDocumentation: ContextualToolHandler = async (args, context) => {
-  const { question, topK = 5 } = args;
-  const docsPath = path.join(context.projectPath, '.arch-docs');
+  const { project_path, question, topK = 5 } = args as { project_path?: string; question: string; topK?: number };
+  // Use project_path from args if provided, otherwise use context.projectPath
+  const projectPath = project_path || context.projectPath;
+  const docsPath = path.join(projectPath, '.arch-docs');
 
   try {
     const vectorService = VectorStoreService.getInstance();
@@ -105,7 +235,18 @@ export const handleQueryDocumentation: ContextualToolHandler = async (args, cont
     }
 
     // Fallback: Read all docs
-    const docService = new DocumentationService(context.config, context.projectPath);
+    if (!context.config) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: '❌ Error: Configuration not found. Please run: archdoc config --init or set environment variables (ANTHROPIC_API_KEY, etc.)',
+          },
+        ],
+        isError: true,
+      };
+    }
+    const docService = new DocumentationService(context.config, projectPath);
     const allContent = await docService.readDocumentationFallback(docsPath);
 
     return {
@@ -131,12 +272,26 @@ export const handleQueryDocumentation: ContextualToolHandler = async (args, cont
 
 /**
  * Handler: update_documentation
+ * Accepts project_path parameter (like CodeWave's repo_path)
  */
 export const handleUpdateDocumentation: ContextualToolHandler = async (args, context) => {
-  const { prompt, existingDocsPath } = args;
+  const { project_path, prompt, existingDocsPath } = args as { project_path?: string; prompt: string; existingDocsPath?: string };
+  // Use project_path from args if provided, otherwise use context.projectPath
+  const projectPath = project_path || context.projectPath;
 
   try {
-    const docService = new DocumentationService(context.config, context.projectPath);
+    if (!context.config) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: '❌ Error: Configuration not found. Please run: archdoc config --init or set environment variables (ANTHROPIC_API_KEY, etc.)',
+          },
+        ],
+        isError: true,
+      };
+    }
+    const docService = new DocumentationService(context.config, projectPath);
     const { output, docsPath } = await docService.updateDocumentation({
       prompt,
       existingDocsPath,
@@ -190,43 +345,46 @@ export const handleAnalyzeDependencies = createSelectiveAgentHandler(
  * Uses factory for selective agent pattern
  */
 export const handleGetRecommendations = createSelectiveAgentHandler(
-  ['recommendation-engine'],
-  'Provide recommendations',
+  // There is no dedicated "recommendation-engine" agent in this repo.
+  // Instead, run the agents that emit recommendations and let the orchestrator
+  // synthesize `recommendations.md` (custom section key: "recommendations").
+  [
+    'architecture-analyzer',
+    'file-structure',
+    'dependency-analyzer',
+    'pattern-detector',
+    'flow-visualization',
+    'schema-generator',
+    'security-analyzer',
+    'kpi-analyzer',
+  ],
+  'Generate prioritized recommendations',
 );
 
 /**
  * Handler: validate_architecture
+ * Accepts project_path parameter (like CodeWave's repo_path)
  */
 export const handleValidateArchitecture: ContextualToolHandler = async (args, context) => {
-  const { filePath } = args;
+  // Keep schema validation responsibility with registry/types; currently not implemented.
+  // (Avoid unused variables while still accepting the args shape.)
+  void args;
+  void context;
 
   try {
-    const docService = new DocumentationService(context.config, context.projectPath);
-    const output = await docService.runSelectiveAgents({
-      selectiveAgents: ['architecture-validator'],
-      userPrompt: `Validate file: ${filePath}`,
-    });
-
-    const valSection = output.customSections.get('architecture-validator') as any;
-
-    if (!valSection) {
-      return {
-        content: [
-          {
-            type: 'text',
-            text: '⚠️ No validation performed',
-          },
-        ],
-      };
-    }
-
+    // CLI does not have a first-class "architecture validation" command in this repo,
+    // and there is no `architecture-validator` agent registered.
+    // Returning a hard error is better than silently reporting success with no output.
     return {
       content: [
         {
           type: 'text',
-          text: valSection.content || valSection.markdown || 'No validation data available',
+          text:
+            '❌ validate_architecture is not implemented yet in this MCP server (no architecture-validator agent exists). ' +
+            'Use generate_documentation (optionally with selectiveAgents) and review the generated docs for architectural constraints.',
         },
       ],
+      isError: true,
     };
   } catch (error) {
     return {

--- a/src/mcp-server/tools/tool-registry.ts
+++ b/src/mcp-server/tools/tool-registry.ts
@@ -12,7 +12,7 @@ export const TOOLS: Record<string, ToolDefinition> = {
   check_config: {
     name: 'check_config',
     description:
-      'Check if .archdoc.config.json exists and is valid. Returns setup instructions if missing or invalid.',
+      'Use when the user asks if ArchDoc is set up or whether the project has valid ArchDoc config. Checks for .archdoc.config.json and returns status or setup instructions. Prefer over guessing when they say "is archdoc configured?", "do I have archdoc set up?", or "check archdoc config".',
     version: '1.0.0',
     versionInfo: {
       current: { major: 1, minor: 0, patch: 0 },
@@ -26,14 +26,19 @@ export const TOOLS: Record<string, ToolDefinition> = {
     },
     inputSchema: {
       type: 'object',
-      properties: {},
+      properties: {
+        project_path: {
+          type: 'string',
+          description: 'Path to project directory (default: current working directory)',
+        },
+      },
     },
   },
 
   setup_config: {
     name: 'setup_config',
     description:
-      'Create or update .archdoc.config.json with user-provided configuration. This tool accepts all configuration options and creates the config file.',
+      'Use when the user wants to create or change ArchDoc configuration (LLM provider, API key, model). Creates or updates .archdoc.config.json. Use for "set up archdoc", "configure archdoc", "add my API key for archdoc", or "change archdoc provider/model". Requires provider, model, and apiKey.',
     version: '1.0.0',
     versionInfo: {
       current: { major: 1, minor: 0, patch: 0 },
@@ -48,6 +53,10 @@ export const TOOLS: Record<string, ToolDefinition> = {
     inputSchema: {
       type: 'object',
       properties: {
+        project_path: {
+          type: 'string',
+          description: 'Path to project directory (default: current working directory)',
+        },
         provider: {
           type: 'string',
           enum: ['anthropic', 'openai', 'google', 'xai'],
@@ -127,7 +136,8 @@ export const TOOLS: Record<string, ToolDefinition> = {
 
   generate_documentation: {
     name: 'generate_documentation',
-    description: 'Generate comprehensive architecture documentation for the current project',
+    description:
+      'Use when the user wants to generate architecture docs from scratch or refresh them after code changes. Creates or updates docs in .arch-docs; supports delta analysis so only changed areas are re-analyzed unless force is true. Use for "document the architecture", "generate architecture docs", "refresh docs after my changes", or "check if docs need updating". Not for adding a single new topic to existing docs (use update_documentation for that).',
     version: '1.0.0',
     versionInfo: {
       current: { major: 1, minor: 0, patch: 0 },
@@ -147,6 +157,10 @@ export const TOOLS: Record<string, ToolDefinition> = {
     inputSchema: {
       type: 'object',
       properties: {
+        project_path: {
+          type: 'string',
+          description: 'Path to project directory (default: current working directory)',
+        },
         outputDir: {
           type: 'string',
           description: 'Output directory (default: .arch-docs)',
@@ -171,6 +185,14 @@ export const TOOLS: Record<string, ToolDefinition> = {
           type: 'number',
           description: 'Maximum cost budget in dollars (default: 5.0)',
         },
+        force: {
+          type: 'boolean',
+          description: 'Force full analysis, ignoring delta analysis (default: false)',
+        },
+        since: {
+          type: 'string',
+          description: 'Git commit/branch/tag to compare against for delta analysis',
+        },
       },
       required: [],
     },
@@ -178,7 +200,8 @@ export const TOOLS: Record<string, ToolDefinition> = {
 
   query_documentation: {
     name: 'query_documentation',
-    description: 'Query existing documentation using RAG (semantic search over docs)',
+    description:
+      'Use when the user asks a question about the project\'s architecture, modules, or design and architecture docs already exist in .arch-docs. Answers from ArchDoc-generated docs via semantic search (RAG). Use for "what are the main modules?", "how does the architecture work?", "explain the design". Not for searching raw code—only for querying existing architecture documentation.',
     version: '1.0.0',
     versionInfo: {
       current: { major: 1, minor: 0, patch: 0 },
@@ -193,6 +216,10 @@ export const TOOLS: Record<string, ToolDefinition> = {
     inputSchema: {
       type: 'object',
       properties: {
+        project_path: {
+          type: 'string',
+          description: 'Path to project directory (default: current working directory)',
+        },
         question: {
           type: 'string',
           description: 'Question to answer from documentation',
@@ -208,7 +235,8 @@ export const TOOLS: Record<string, ToolDefinition> = {
 
   update_documentation: {
     name: 'update_documentation',
-    description: 'Update existing documentation with new focus area (incremental mode)',
+    description:
+      'Use when the user wants to add or extend existing architecture docs with a new focus (e.g. security, API layer) without regenerating everything. Takes a prompt describing what to add; updates .arch-docs incrementally. Use for "add security analysis to the docs", "document the API layer", "expand docs to cover X". Not for full generate/refresh (use generate_documentation for that). Requires prompt.',
     version: '1.0.0',
     versionInfo: {
       current: { major: 1, minor: 0, patch: 0 },
@@ -223,6 +251,10 @@ export const TOOLS: Record<string, ToolDefinition> = {
     inputSchema: {
       type: 'object',
       properties: {
+        project_path: {
+          type: 'string',
+          description: 'Path to project directory (default: current working directory)',
+        },
         prompt: {
           type: 'string',
           description:
@@ -239,7 +271,8 @@ export const TOOLS: Record<string, ToolDefinition> = {
 
   check_architecture_patterns: {
     name: 'check_architecture_patterns',
-    description: 'Detect design patterns and anti-patterns in code',
+    description:
+      'Use when the user wants to find design patterns or anti-patterns in the codebase. Scans code for patterns and anti-patterns; does not require existing architecture docs. Use for "what patterns does this use?", "find anti-patterns", "review code for bad patterns". Optional: pass filePaths to limit to specific files.',
     version: '1.0.0',
     versionInfo: {
       current: { major: 1, minor: 0, patch: 0 },
@@ -259,6 +292,10 @@ export const TOOLS: Record<string, ToolDefinition> = {
     inputSchema: {
       type: 'object',
       properties: {
+        project_path: {
+          type: 'string',
+          description: 'Path to project directory (default: current working directory)',
+        },
         filePaths: {
           type: 'array',
           items: { type: 'string' },
@@ -271,7 +308,8 @@ export const TOOLS: Record<string, ToolDefinition> = {
 
   analyze_dependencies: {
     name: 'analyze_dependencies',
-    description: 'Analyze project dependencies, detect circular deps, outdated packages',
+    description:
+      'Use when the user asks about dependencies, circular dependencies, or outdated packages. Analyzes package manifests (e.g. package.json) for dependency graph, circular deps, and outdated packages. Use for "any circular deps?", "are dependencies up to date?", "show dependency graph". Prefer over reading package.json manually.',
     version: '1.0.0',
     versionInfo: {
       current: { major: 1, minor: 0, patch: 0 },
@@ -291,6 +329,10 @@ export const TOOLS: Record<string, ToolDefinition> = {
     inputSchema: {
       type: 'object',
       properties: {
+        project_path: {
+          type: 'string',
+          description: 'Path to project directory (default: current working directory)',
+        },
         includeDevDeps: {
           type: 'boolean',
           description: 'Include dev dependencies (default: true)',
@@ -302,7 +344,8 @@ export const TOOLS: Record<string, ToolDefinition> = {
 
   get_recommendations: {
     name: 'get_recommendations',
-    description: 'Get improvement recommendations for the project',
+    description:
+      'Use when the user asks for improvement suggestions, refactoring ideas, or what to fix. Returns ArchDoc-generated recommendations (security, performance, maintainability). Use for "how can I improve this project?", "what should I refactor?", "suggest improvements". Optional focusArea: security, performance, maintainability, or all.',
     version: '1.0.0',
     versionInfo: {
       current: { major: 1, minor: 0, patch: 0 },
@@ -321,6 +364,10 @@ export const TOOLS: Record<string, ToolDefinition> = {
     inputSchema: {
       type: 'object',
       properties: {
+        project_path: {
+          type: 'string',
+          description: 'Path to project directory (default: current working directory)',
+        },
         focusArea: {
           type: 'string',
           enum: ['security', 'performance', 'maintainability', 'all'],
@@ -333,7 +380,8 @@ export const TOOLS: Record<string, ToolDefinition> = {
 
   validate_architecture: {
     name: 'validate_architecture',
-    description: 'Validate if code follows documented architecture patterns',
+    description:
+      'Use when the user wants to check if a specific file or module follows the documented architecture. Validates the given files against existing architecture docs in .arch-docs; requires docs to have been generated first. Use for "does this file follow our architecture?", "check this file for architecture violations". Requires filePath. Not for detecting patterns in code (use check_architecture_patterns for that).',
     version: '1.0.0',
     versionInfo: {
       current: { major: 1, minor: 0, patch: 0 },
@@ -353,6 +401,10 @@ export const TOOLS: Record<string, ToolDefinition> = {
     inputSchema: {
       type: 'object',
       properties: {
+        project_path: {
+          type: 'string',
+          description: 'Path to project directory (default: current working directory)',
+        },
         filePath: {
           type: 'string',
           description: 'File to validate against architecture',

--- a/src/mcp-server/types.ts
+++ b/src/mcp-server/types.ts
@@ -67,7 +67,7 @@ export interface ToolDefinition {
  */
 export interface ToolContext {
   projectPath: string;
-  config: ArchDocConfig;
+  config: ArchDocConfig | null; // Nullable to support dynamic loading
   logger: any; // Logger instance
 }
 

--- a/src/orchestrator/documentation-orchestrator.ts
+++ b/src/orchestrator/documentation-orchestrator.ts
@@ -279,6 +279,10 @@ export class DocumentationOrchestrator {
 
     // Get all agents and sort by dependencies (topological sort)
     let agents = this.agentRegistry.getAllAgents();
+    if (agents.length === 0) {
+      this.logger.error('AgentRegistry is empty! This should not happen.');
+      throw new Error('No agents registered in AgentRegistry. Agents must be registered before creating the orchestrator.');
+    }
 
     // Filter agents if selective list provided (from refinement check)
     if (options.selectiveAgents && options.selectiveAgents.length > 0) {
@@ -293,6 +297,10 @@ export class DocumentationOrchestrator {
     const agentNames = sortedAgents.map((a) => a.getMetadata().name);
 
     this.logger.info(`Found ${agentNames.length} agents: ${agentNames.join(', ')}`);
+    if (agentNames.length === 0) {
+      this.logger.error(`[ERROR] No agent names after sorting! This should not happen.`);
+      throw new Error('No agents available after filtering and sorting. Check agent registration.');
+    }
 
     // Validate embeddings API key if vector search mode is enabled
     if (options.agentOptions?.searchMode === 'vector') {
@@ -444,9 +452,13 @@ export class DocumentationOrchestrator {
       if (nodeNames.length > 0) {
         const lastNodeName = nodeNames[nodeNames.length - 1];
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        finalState = (state as any)[lastNodeName] || finalState;
+        const nodeState = (state as any)[lastNodeName];
+        if (nodeState) {
+          finalState = nodeState;
+        }
       }
     }
+
 
     if (!finalState.output) {
       throw new Error('Documentation generation failed: no output produced');
@@ -671,11 +683,14 @@ IMPROVEMENTS: [List specific improvements needed, one per line, or "none" if no 
     this.logger.info('🔄 Running only agents that need updates...');
 
     // Run selective regeneration with only the agents that need updates
+    // Force full analysis since refinement check already determined updates are needed
+    // Delta analysis might filter out files, but we need to analyze them for the selected agents
     const output = await this.generateDocumentation(projectPath, {
       ...options,
       incrementalMode: false,
       existingDocsPath: undefined,
-      selectiveAgents: agentsToRun, // NEW: Pass list of agents to run
+      selectiveAgents: agentsToRun, // Pass list of agents to run
+      force: true, // Force full analysis - refinement check already determined updates are needed
     });
 
     // Mark as refinement mode for changelog formatting
@@ -1917,8 +1932,13 @@ Needs Update: ${evaluation.needsUpdate}
     }
 
     // Check if delta analysis is available
-    if (!scanResult.deltaAnalysis?.enabled) {
-      this.logger.info('Delta analysis not available: performing full analysis');
+    // Also skip if scanResult has no files (shouldn't happen, but safety check)
+    if (!scanResult.deltaAnalysis?.enabled || scanResult.files.length === 0) {
+      if (scanResult.files.length === 0) {
+        this.logger.warn('⚠️ Scan result has 0 files - this should not happen. Check project path and scanner configuration.');
+      } else {
+        this.logger.info('Delta analysis not available: performing full analysis');
+      }
       return {
         filteredScanResult: scanResult,
         cachedResults,
@@ -1967,6 +1987,23 @@ Needs Update: ${evaluation.needsUpdate}
       this.logger.info(
         `Change summary: ${scanResult.deltaAnalysis.changedFiles} changed, ${scanResult.deltaAnalysis.newFiles} new, ${scanResult.deltaAnalysis.unchangedFiles} unchanged`,
       );
+    }
+
+    // If delta analysis filtered out ALL files, fall back to full analysis
+    // This can happen when all files are unchanged but user wants to regenerate/update docs
+    if (filteredFiles.length === 0 && scanResult.files.length > 0) {
+      this.logger.warn(
+        `⚠️ Delta analysis filtered out all files (all unchanged). Falling back to full analysis of all ${scanResult.files.length} files.`,
+      );
+      this.logger.info(
+        '💡 Tip: Use --force flag to always perform full analysis, or modify files to trigger delta analysis.',
+      );
+      // Return full scan result instead of filtered
+      return {
+        filteredScanResult: scanResult,
+        cachedResults,
+        savings: { filesSkipped: 0, estimatedTokensSaved: 0 },
+      };
     }
 
     // Create filtered scan result


### PR DESCRIPTION
- **VS Code + Copilot:** Setup now writes to the VS Code user profile (~/Library/Application Support/Code/User/mcp.json on macOS, etc.) and uses the servers key so archdoc appears in the MCP list. Added --global for global installs.

- **MCP ↔ CLI alignment**: All MCP tools accept project_path. generate_documentation supports force and since. Handlers and documentation service pass these through to the orchestrator so behavior matches the CLI.

- **Docs**: [MCP-SETUP.md](docs/MCP-SETUP.md) updated with correct VS Code paths, “MCP: Open User Configuration,” and a tip for --global.
