### PR TITLE
Fix Gemini empty/blocked response handling (OpenAI embeddings)

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,56 @@
+# Troubleshooting
+
+## Archdoc analyze fails with Google Gemini 2.5 Pro + OpenAI Embeddings
+
+### Symptom
+
+When running `archdoc analyze` with **Google Gemini 2.5 Pro** as the LLM and **OpenAI Embeddings**, the architecture-analyzer agent may fail with:
+
+```
+TypeError: Cannot read properties of undefined (reading 'length')
+    at mapGenerateContentResultToChatResult (.../node_modules/@langchain/google-genai/dist/utils/common.cjs:229:32)
+```
+
+### Root cause
+
+The error occurs inside **`@langchain/google-genai`** (the LangChain integration for Google's Generative AI SDK), not in Archdoc itself.
+
+- **Where it happens:** In `mapGenerateContentResultToChatResult` in `dist/utils/common.cjs`. The code assumes every response candidate has a `content.parts` array.
+- **Why it breaks:** With **Gemini 2.5 Pro**, the Google API can sometimes return a candidate where `content` has no `parts` (or `parts` is undefined). This can happen when:
+  - The response was blocked by a safety filter (`finishReason: SAFETY`)
+  - The output token limit was reached (`finishReason: MAX_TOKENS`) and the API returns no parts
+  - Other API/response reasons
+
+Helper steps (e.g. security pattern discovery, architecture style) and clarity evaluation use increased token limits to reduce MAX_TOKENS on short answers.
+
+When that happens, the library tries to read `.length` on `undefined`, which triggers the TypeError. See [Google's documentation](https://discuss.ai.google.dev/t/gemini-api-returns-undefined-response-causing-candidate-content-parts-error-in-production/110886) on handling empty/blocked responses.
+
+### What we do
+
+This project applies a **patch** to `@langchain/google-genai@0.1.12` so that when the API returns a candidate with no `content.parts`, we return **one empty generation** (empty text) and filters instead of crashing. That way both the mapping code and the caller (`chat_models.cjs`, which reads `generations[0].text`) stay safe. The patch is applied automatically after `npm install` via `patch-package` (see `patches/@langchain+google-genai+0.1.12.patch`).
+
+**Visibility:** The patch does not log by default. When Gemini returns empty/blocked content, you will see **one warning per affected step** from the application (e.g. "Initial analysis returned empty content", or helper fallbacks for security/architecture style). For full evidence from the library (e.g. for issue reporting), run:
+
+```bash
+DEBUG=langchain archdoc analyze
+```
+
+You will then see the patch’s **Evidence** object: `finishReason`, `promptFeedback`, `contentKeys`, etc.
+
+**App-level checks:** If the main initial analysis or clarity evaluation returns empty content, the workflow logs a warning so you know a critical step got no output. Helper steps (e.g. security pattern discovery, architecture style detection) also log when they fall back due to empty response.
+
+### If you still see the error
+
+1. Ensure you have run `npm install` so the patch is applied (check that `patches/@langchain+google-genai+0.1.12.patch` exists and `postinstall` runs `patch-package`).
+2. If you use a different package manager (e.g. pnpm), you may need to ensure `patch-package` runs after install, or use pnpm's built-in patching.
+3. As a workaround, use another Google model that may not trigger this path: e.g. `gemini-1.5-pro` or `gemini-2.0-flash-exp` in your config.
+
+### Summary
+
+| Item                    | Detail                                                                                                        |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------- |
+| **Error**               | `TypeError: Cannot read properties of undefined (reading 'length')` in `mapGenerateContentResultToChatResult` |
+| **Location**            | `@langchain/google-genai` response mapping                                                                    |
+| **Trigger**             | Gemini returning a candidate without `content.parts` (e.g. safety block)                                      |
+| **Fix in this project** | Patched dependency via `patch-package`; guard for missing/empty `parts`                                       |
+| **Workaround**          | Use `gemini-1.5-pro` or `gemini-2.0-flash-exp` if the patch is not applied                                    |

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@techdebtgpt/archdoc-generator",
       "version": "0.3.39",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.68.0",
@@ -44,6 +45,7 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.0",
         "jest": "^29.7.0",
+        "patch-package": "^8.0.0",
         "prettier": "^3.1.1",
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.2",
@@ -2062,6 +2064,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -2627,6 +2636,25 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -3118,6 +3146,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/delayed-stream": {
@@ -3947,6 +3993,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
@@ -4020,6 +4076,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/fs.realpath": {
@@ -4263,6 +4334,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -4529,6 +4613,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4627,6 +4727,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -5359,6 +5479,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -5379,6 +5519,29 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/jsonpointer": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
@@ -5396,6 +5559,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kleur": {
@@ -5920,6 +6093,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -5960,6 +6143,23 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6188,6 +6388,46 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/path-exists": {
@@ -6983,6 +7223,24 @@
         "node": ">= 18"
       }
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -7384,6 +7642,16 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "license": "MIT"
     },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -7657,6 +7925,16 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "mcp:setup": "ts-node cli/commands/setup-mcp.command.ts",
     "example:basic": "ts-node examples/basic-usage.ts",
     "example:custom": "ts-node examples/custom-agent.ts",
-    "prepublish:check": "node scripts/pre-publish-check.js"
+    "prepublish:check": "node scripts/pre-publish-check.js",
+    "postinstall": "patch-package"
   },
   "keywords": [
     "documentation",
@@ -102,6 +103,7 @@
   },
   "devDependencies": {
     "@types/inquirer": "^9.0.7",
+    "patch-package": "^8.0.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.19.0",
     "@typescript-eslint/eslint-plugin": "^8.46.2",

--- a/patches/@langchain+google-genai+0.1.12.patch
+++ b/patches/@langchain+google-genai+0.1.12.patch
@@ -1,0 +1,92 @@
+diff --git a/node_modules/@langchain/google-genai/dist/utils/common.cjs b/node_modules/@langchain/google-genai/dist/utils/common.cjs
+index 8422e8c..0a38553 100644
+--- a/node_modules/@langchain/google-genai/dist/utils/common.cjs
++++ b/node_modules/@langchain/google-genai/dist/utils/common.cjs
+@@ -225,8 +225,40 @@ function mapGenerateContentResultToChatResult(response, extra) {
+     const functionCalls = response.functionCalls();
+     const [candidate] = response.candidates;
+     const { content: candidateContent, ...generationInfo } = candidate;
++    // Handle blocked/empty candidate content (e.g. SAFETY, MAX_TOKENS) - avoid reading .length on undefined
++    if (!candidateContent?.parts || candidateContent.parts.length === 0) {
++        const finishReason = candidate?.finishReason;
++        if (typeof process !== "undefined" && process.env?.DEBUG?.includes("langchain")) {
++            console.warn("[@langchain/google-genai] Empty/blocked content; returning empty generation. Evidence:", JSON.stringify({
++                hasCandidate: !!candidate,
++                hasContent: !!candidateContent,
++                contentKeys: candidateContent ? Object.keys(candidateContent) : [],
++                finishReason,
++                promptFeedback: response.promptFeedback,
++            }, null, 2));
++        }
++        return {
++            generations: [{
++                text: "",
++                message: new messages_1.AIMessage({
++                    content: "",
++                    additional_kwargs: generationInfo,
++                    usage_metadata: extra?.usageMetadata,
++                }),
++                generationInfo,
++            }],
++            llmOutput: {
++                filters: response.promptFeedback,
++                tokenUsage: extra?.usageMetadata ? {
++                    promptTokens: extra?.usageMetadata?.input_tokens,
++                    completionTokens: extra?.usageMetadata?.output_tokens,
++                    totalTokens: extra?.usageMetadata?.total_tokens,
++                } : undefined,
++            },
++        };
++    }
+     let content;
+-    if (candidateContent?.parts.length === 1 && candidateContent.parts[0].text) {
++    if (candidateContent.parts.length === 1 && candidateContent.parts[0].text) {
+         content = candidateContent.parts[0].text;
+     }
+     else {
+diff --git a/node_modules/@langchain/google-genai/dist/utils/common.js b/node_modules/@langchain/google-genai/dist/utils/common.js
+index ad800f9..093d810 100644
+--- a/node_modules/@langchain/google-genai/dist/utils/common.js
++++ b/node_modules/@langchain/google-genai/dist/utils/common.js
+@@ -218,8 +218,40 @@ export function mapGenerateContentResultToChatResult(response, extra) {
+     const functionCalls = response.functionCalls();
+     const [candidate] = response.candidates;
+     const { content: candidateContent, ...generationInfo } = candidate;
++    // Handle blocked/empty candidate content (e.g. SAFETY, MAX_TOKENS) - avoid reading .length on undefined
++    if (!candidateContent?.parts || candidateContent.parts.length === 0) {
++        const finishReason = candidate?.finishReason;
++        if (typeof process !== "undefined" && process.env?.DEBUG?.includes("langchain")) {
++            console.warn("[@langchain/google-genai] Empty/blocked content; returning empty generation. Evidence:", JSON.stringify({
++                hasCandidate: !!candidate,
++                hasContent: !!candidateContent,
++                contentKeys: candidateContent ? Object.keys(candidateContent) : [],
++                finishReason,
++                promptFeedback: response.promptFeedback,
++            }, null, 2));
++        }
++        return {
++            generations: [{
++                text: "",
++                message: new AIMessage({
++                    content: "",
++                    additional_kwargs: generationInfo,
++                    usage_metadata: extra?.usageMetadata,
++                }),
++                generationInfo,
++            }],
++            llmOutput: {
++                filters: response.promptFeedback,
++                tokenUsage: extra?.usageMetadata ? {
++                    promptTokens: extra?.usageMetadata?.input_tokens,
++                    completionTokens: extra?.usageMetadata?.output_tokens,
++                    totalTokens: extra?.usageMetadata?.total_tokens,
++                } : undefined,
++            },
++        };
++    }
+     let content;
+-    if (candidateContent?.parts.length === 1 && candidateContent.parts[0].text) {
++    if (candidateContent.parts.length === 1 && candidateContent.parts[0].text) {
+         content = candidateContent.parts[0].text;
+     }
+     else {

--- a/src/agents/architecture-analyzer-agent.ts
+++ b/src/agents/architecture-analyzer-agent.ts
@@ -183,7 +183,7 @@ Based on this structure, identify the architectural style, major components, lay
     context: AgentContext,
     structure: ReturnType<typeof this.analyzeProjectStructure>,
   ): Promise<string> {
-    const model = this.llmService.getChatModel({ temperature: 0.1, maxTokens: 100 });
+    const model = this.llmService.getChatModel({ temperature: 0.1, maxTokens: 1500 });
 
     const prompt = `Based on this project structure, identify the most likely architectural style in ONE WORD:
 

--- a/src/agents/base-agent-workflow.ts
+++ b/src/agents/base-agent-workflow.ts
@@ -566,6 +566,13 @@ export abstract class BaseAgentWorkflow {
 
     const analysisText = typeof result === 'string' ? result : result.content?.toString() || '';
 
+    if (!analysisText || analysisText.trim().length === 0) {
+      this.logger.warn(
+        'Initial analysis returned empty content (e.g. blocked or MAX_TOKENS); this step may use fallback behavior.',
+        '⚠️',
+      );
+    }
+
     // Try to extract tokens directly from the response object if callback failed
     if (actualOutputTokens === 0 && typeof result !== 'string') {
       const responseUsage =
@@ -667,7 +674,7 @@ export abstract class BaseAgentWorkflow {
 
     const modelOptions = {
       temperature: 0.2,
-      maxTokens: 2000,
+      maxTokens: 3072,
     };
 
     const model = this.llmService.getChatModel(modelOptions, agentName);
@@ -733,6 +740,13 @@ MISSING_INFORMATION:
     this.logger.info(`Evaluation completed in ${evalDuration}s`, '✅');
 
     const evaluationText = typeof result === 'string' ? result : result.content?.toString() || '';
+
+    if (!evaluationText || evaluationText.trim().length === 0) {
+      this.logger.warn(
+        'Clarity evaluation returned empty content (e.g. blocked or MAX_TOKENS); scores will be treated as 0.',
+        '⚠️',
+      );
+    }
 
     // Try to extract tokens directly from the response object if callback failed
     if (actualOutputTokens === 0 && typeof result !== 'string') {

--- a/src/agents/security-analyzer-agent.ts
+++ b/src/agents/security-analyzer-agent.ts
@@ -214,7 +214,7 @@ Please perform a comprehensive security analysis:
    */
   private async discoverSecurityPatterns(context: AgentContext): Promise<string[]> {
     try {
-      const model = this.llmService.getChatModel({ temperature: 0.1, maxTokens: 500 });
+      const model = this.llmService.getChatModel({ temperature: 0.1, maxTokens: 2048 });
 
       // Sample a few representative files to understand project type
       const sampleFiles = context.files
@@ -245,6 +245,14 @@ Return ONLY a JSON array of 5-10 lowercase keywords/patterns specific to this pr
       const response = await model.invoke(prompt, { runName: 'security-pattern-discovery' });
       const content = typeof response.content === 'string' ? response.content : '';
 
+      if (!content || content.trim().length === 0) {
+        this.logger.warn(
+          'discoverSecurityPatterns: LLM returned empty content (e.g. MAX_TOKENS); using base keywords only.',
+          '⚠️',
+        );
+        return [];
+      }
+
       // Parse JSON array from response
       const parsed = LLMJsonParser.parse<string[]>(content, {
         contextName: 'security-pattern-discovery',
@@ -252,14 +260,21 @@ Return ONLY a JSON array of 5-10 lowercase keywords/patterns specific to this pr
         fallback: [],
       });
 
-      this.logger.debug('Discovered project-specific security patterns', {
-        patterns: parsed,
-      });
+      const patterns = Array.isArray(parsed) ? parsed : [];
+      if (patterns.length === 0) {
+        this.logger.debug('Discovered no extra security patterns; using base keywords only');
+      } else {
+        this.logger.debug('Discovered project-specific security patterns', { patterns });
+      }
 
-      return Array.isArray(parsed) ? parsed : [];
+      return patterns;
     } catch (error) {
       // Fallback: return empty array if discovery fails
-      this.logger.debug('Failed to discover security patterns, using base keywords only', {
+      this.logger.warn(
+        'discoverSecurityPatterns: failed (parse or network); using base keywords only.',
+        '⚠️',
+      );
+      this.logger.debug('discoverSecurityPatterns error', {
         error: error instanceof Error ? error.message : String(error),
       });
       return [];


### PR DESCRIPTION
## Problem
With Google Gemini (e.g. 2.5 Pro) + OpenAI embeddings, `archdoc analyze` could crash with:
`TypeError: Cannot read properties of undefined (reading 'length')` in `@langchain/google-genai` when the API returned a candidate without `content.parts` (e.g. MAX_TOKENS or SAFETY).

## Solution
- **Patch** `@langchain/google-genai@0.1.12`: when the API returns empty/blocked content, return one empty generation instead of crashing. Patch logs only when `DEBUG=langchain`.
- **App-level handling**: log one warning per affected step when analysis/clarity or helpers get empty content; use fallbacks (base keywords, default "layered", clarity=0).
- **Token limits**: increased maxTokens for clarity evaluation (base-agent-workflow), discoverSecurityPatterns (security-analyzer), and detectArchitectureStyle (architecture-analyzer) to reduce MAX_TOKENS empty responses.
- **Docs**: updated `docs/TROUBLESHOOTING.md` with cause, fix, and how to use `DEBUG=langchain` for evidence.

## Testing

- [x] Manual run with Gemini + OpenAI embeddings completes without crash; when empty content occurs, app warns and uses fallbacks.

Fixes #11 